### PR TITLE
fix(cmd/tblconv): validate exact num of args to prevent index issues

### DIFF
--- a/cmd/tblconv/cmd/output/output.go
+++ b/cmd/tblconv/cmd/output/output.go
@@ -60,6 +60,7 @@ func Commands() []*cobra.Command {
 		cmd := &cobra.Command{
 			Use:   fmt.Sprintf("%s [flags] FILE|-", o.name),
 			Short: o.short,
+			Args:  cobra.ExactArgs(1),
 		}
 
 		o.withFlags(cmd)


### PR DESCRIPTION
Closes #20 